### PR TITLE
fix: show pre-loaded model status in Gradio UI when initialized via CLI arguments

### DIFF
--- a/run_mimo_asr.py
+++ b/run_mimo_asr.py
@@ -86,7 +86,7 @@ class MiMoV25ASRInterface:
             print(error_msg)
             return "", error_msg
 
-    def create_interface(self, default_model_path="", default_tokenizer_path=""):
+    def create_interface(self, default_model_path="", default_tokenizer_path="", init_status_msg=""):
         with gr.Blocks(title="MiMo-V2.5-ASR Speech Recognition", theme=gr.themes.Soft()) as iface:
             gr.Markdown("# MiMo-V2.5-ASR: Robust Speech Recognition")
             gr.Markdown(
@@ -122,6 +122,7 @@ class MiMoV25ASRInterface:
                                 label="Initialization status",
                                 interactive=False,
                                 lines=6,
+                                value=init_status_msg,
                                 placeholder="Click the initialize model button to start...",
                             )
                             gr.Markdown("### System information")
@@ -221,14 +222,17 @@ def main():
     print("Launch MiMo-V2.5-ASR demo...")
     interface = MiMoV25ASRInterface()
 
+    init_status_msg = ""
     if args.model_path or args.tokenizer_path:
         print("Initializing model from command-line paths...")
-        print(interface.initialize_model(args.model_path, args.tokenizer_path))
+        init_status_msg = interface.initialize_model(args.model_path, args.tokenizer_path)
+        print(init_status_msg)
 
     print("Create Gradio interface...")
     iface = interface.create_interface(
         default_model_path=args.model_path or "",
         default_tokenizer_path=args.tokenizer_path or "",
+        init_status_msg=init_status_msg,
     )
 
     print(f"Launch service - {args.host}:{args.port}")


### PR DESCRIPTION
Description:

  ## Problem

  When the model is loaded at startup via `--model-path` and `--tokenizer-path` CLI arguments,
  the "Initialization status" textbox in the Gradio UI still shows the placeholder text
  *"Click the initialize model button to start..."*, giving the false impression that the model
  has not been initialized yet.

  ## Solution

  Pass the initialization result message from `initialize_model()` into `create_interface()` as
  `init_status_msg`, and use it as the initial `value` of the status textbox. When the model is
  pre-loaded via CLI, the UI immediately reflects the actual state ("Model loaded successfully!")
  on page load.

  ## Changes

  - `create_interface()` now accepts an optional `init_status_msg` parameter (defaults to `""`)
  - The "Initialization status" textbox is pre-populated with this value at render time
  - `main()` captures the return value of `initialize_model()` and forwards it to `create_interface()`

  ## Behavior After Fix

  | Scenario | Before | After |
  |---|---|---|
  | Model loaded via CLI args | Shows placeholder text | Shows "Model loaded successfully!" |
  | No CLI args (manual init) | Shows placeholder text | Shows placeholder text (unchanged) |