### PR TITLE
docs: fix incorrect argument name in Python API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ from src.mimo_audio.mimo_audio import MimoAudio
 
 model = MimoAudio(
     model_path="./models/MiMo-V2.5-ASR",
-    tokenizer_path="./models/MiMo-Audio-Tokenizer",
+    mimo_audio_tokenizer_path="./models/MiMo-Audio-Tokenizer",
 )
 
 # Automatic language detection (recommended for code-switching)


### PR DESCRIPTION
Update argument name to match MimoAudio.__init__ in src/mimo_audio/mimo_audio.py